### PR TITLE
Fix certifier validation

### DIFF
--- a/auth/certificates/verifiable.go
+++ b/auth/certificates/verifiable.go
@@ -132,7 +132,7 @@ func (vc *VerifiableCertificate) DecryptFields(
 		fieldRevelationKey := decryptResult.Plaintext
 
 		// 2. Decrypt the actual field value using the field revelation key.
-		encryptedFieldValueBase64, exists := vc.Fields[wallet.CertificateFieldNameUnder50Bytes(fieldName)]
+		encryptedFieldValueBase64, exists := vc.Fields[fieldName]
 		if !exists {
 			// This case should ideally not happen if the keyring is consistent with fields,
 			// but handle it defensively.

--- a/auth/peer.go
+++ b/auth/peer.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -841,16 +842,14 @@ func (p *Peer) handleCertificateResponse(ctx context.Context, message *AuthMessa
 			utilsRequestedCerts,
 		)
 		if err != nil {
-			// Log the error but continue - certificate error shouldn't stop auth
-			p.logger.Printf("Warning: Certificate validation failed: %v", err)
+			return errors.Join(ErrCertificateValidation, err)
 		}
 
 		// Notify certificate listeners
 		for _, callback := range p.onCertificateReceivedCallbacks {
 			err := callback(senderPublicKey, message.Certificates)
 			if err != nil {
-				// Log callback error but continue
-				p.logger.Printf("Warning: Certificate callback error: %v", err)
+				return fmt.Errorf("certificate received callback error: %w", err)
 			}
 		}
 	}

--- a/auth/peer.go
+++ b/auth/peer.go
@@ -545,7 +545,7 @@ func (p *Peer) handleInitialResponse(ctx context.Context, message *AuthMessage, 
 		return ErrInvalidNonce
 	}
 
-	session, err := p.sessionManager.GetSession(senderPublicKey.ToDERHex())
+	session, err := p.sessionManager.GetSession(message.YourNonce)
 	if err != nil || session == nil {
 		return ErrSessionNotFound
 	}
@@ -560,7 +560,7 @@ func (p *Peer) handleInitialResponse(ctx context.Context, message *AuthMessage, 
 		return NewAuthError("failed to decode session nonce", err)
 	}
 	// Concatenate the decoded bytes
-	sigData := append(initialNonceBytes, sessionNonceBytes...)
+	sigData := append(sessionNonceBytes, initialNonceBytes...)
 
 	signature, err := ec.ParseSignature(message.Signature)
 	if err != nil {
@@ -576,7 +576,7 @@ func (p *Peer) handleInitialResponse(ctx context.Context, message *AuthMessage, 
 				SecurityLevel: wallet.SecurityLevelEveryAppAndCounterparty,
 				Protocol:      AUTH_PROTOCOL_ID,
 			},
-			KeyID: fmt.Sprintf("%s %s", message.InitialNonce, session.SessionNonce),
+			KeyID: fmt.Sprintf("%s %s", session.SessionNonce, message.InitialNonce),
 			Counterparty: wallet.Counterparty{
 				Type:         wallet.CounterpartyTypeOther,
 				Counterparty: message.IdentityKey,

--- a/primitives/ec/symmetric.go
+++ b/primitives/ec/symmetric.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"log"
 
 	aesgcm "github.com/bsv-blockchain/go-sdk/primitives/aesgcm"
@@ -11,6 +12,16 @@ import (
 
 type SymmetricKey struct {
 	key []byte
+}
+
+// EncryptString decrypts the given message using the symmetric key using AES-GCM
+// It is a convenient wrapper for encrypting strings instead of bytes.
+func (s *SymmetricKey) EncryptString(message string) (ciphertext string, err error) {
+	result, err := s.Encrypt([]byte(message))
+	if err != nil {
+		return "", fmt.Errorf("failed to encrypt string: %w", err)
+	}
+	return string(result), nil
 }
 
 // Encrypt encrypts the given message using the symmetric key using AES-GCM
@@ -31,6 +42,16 @@ func (s *SymmetricKey) Encrypt(message []byte) (ciphertext []byte, err error) {
 	copy(result[len(iv):], ciphertext)
 	copy(result[len(iv)+len(ciphertext):], tag)
 	return result, nil
+}
+
+// DecryptString decrypts the given message using the symmetric key using AES-GCM
+// It is a convenient wrapper for decrypting strings instead of bytes.
+func (s *SymmetricKey) DecryptString(message string) (plaintext string, err error) {
+	result, err := s.Decrypt([]byte(message))
+	if err != nil {
+		return "", fmt.Errorf("failed to decrypt string: %w", err)
+	}
+	return string(result), nil
 }
 
 // Decrypt decrypts the given message using the symmetric key using AES-GCM


### PR DESCRIPTION
1. fix for signature verification on initial response
2. fix failing tests for certificates
3. add option to skip certifier validation if certifiers are not defined in certificate request
4. unify VerifyCertificate functions 
5. add checks for context done in VerifyCertificate - to save some resources and prevent panics in case of earlier finish